### PR TITLE
Pass validation_stringency to the downstream gridss script.

### DIFF
--- a/gridss-purple-linx.sh
+++ b/gridss-purple-linx.sh
@@ -406,6 +406,7 @@ if [[ ! -f $gridss_driver_vcf ]] ; then
 		-b ${blacklist} \
 		-c ${gridss_properties} \
 		--repeatmaskerbed ${repeatmasker} \
+      --picardoptions VALIDATION_STRINGENCY=$validation_stringency \
 		--jvmheap $jvmheap \
 		$gridss_args \
 		${normal_bam} ${tumour_bam}


### PR DESCRIPTION
After adding the "validation_stringency" config option. It was not passed to the gridss.sh script downstream. This was fixed by adding the : "--picardoptions VALIDATION_STRINGENCY=$validation_stringency ". 